### PR TITLE
remove non-FQDN choice for `plugin` config parameter

### DIFF
--- a/plugins/inventory/openstack.py
+++ b/plugins/inventory/openstack.py
@@ -22,7 +22,7 @@ options:
     plugin:
         description: token that ensures this is a source file for the 'openstack' plugin.
         required: True
-        choices: ['openstack', 'openstack.cloud.openstack']
+        choices: ['openstack.cloud.openstack']
     show_all:
         description: toggles showing all vms vs only those with a working IP
         type: bool

--- a/tests/unit/plugins/inventory/test_openstack.py
+++ b/tests/unit/plugins/inventory/test_openstack.py
@@ -27,7 +27,7 @@ from ansible.template import Templar
 
 
 config_data = {
-    'plugin': 'openstack',
+    'plugin': 'openstack.cloud.openstack',
     'compose': {
         'composed_var': '"testvar-" + testvar',
     },


### PR DESCRIPTION
With 
```bash
ansible==4.5.0
ansible-core==2.11.5
```
Using the non-FQDN plugin name in the inventory file, i.e.

```yml
# openstack.yml
plugin: openstack
expand_hostvares: no
...
```
leads to:

```bash
[WARNING]:  * Failed to parse /path/to/file/openstack.yml with
ansible_collections.openstack.cloud.plugins.inventory.openstack plugin: Incorrect plugin name in file: openstack
```
[This exception](https://github.com/j-i-l/ansible/blob/3aaf0e3462ead147d99a39cb2be44cc0442a2e1c/lib/ansible/plugins/inventory/__init__.py#L232-L234) occurs in the method [`_read_config_data`](https://github.com/j-i-l/ansible/blob/3aaf0e3462ead147d99a39cb2be44cc0442a2e1c/lib/ansible/plugins/inventory/__init__.py#L213) from [`BaseInventoryPlugin`](https://github.com/j-i-l/ansible/blob/3aaf0e3462ead147d99a39cb2be44cc0442a2e1c/lib/ansible/plugins/inventory/__init__.py#L149).
It seems that  'openstack' is not considered to be a valid plugin name.

Using the FQDN `openstack.cloud.openstack` as value for the `plugin` parameter works fine.

So, the suggestion is to simply remove the non-FQDN choice.