### PR TITLE
Avoid flagging ResourceNotFound as failed when desired state is 'absent'.

### DIFF
--- a/plugins/module_utils/openstack.py
+++ b/plugins/module_utils/openstack.py
@@ -416,6 +416,9 @@ class OpenStackModule:
             if results and isinstance(results, dict):
                 self.ansible.exit_json(**results)
         except self.sdk.exceptions.OpenStackCloudException as e:
+            if isinstance(e, self.sdk.exceptions.ResourceNotFound) and self.params['state'] == 'absent':
+                # When state==absent no resource found is already the desired state
+                self.ansible.exit_json(changed=False)
             params = {
                 'msg': str(e),
                 'extra_data': {


### PR DESCRIPTION
When trying to decommission some openstack resources I found that the playbook was reporting Failed if the resource was previously removed, however when we indicate that we'd like the state to be/become absent, not finding the resource indicates that the state was as desired from before, and no change is necessary, hence I suggest that we catch this in the general run wrapper and return changed=False.